### PR TITLE
Replace form with CTA button

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,18 +195,10 @@
                     <h3 class="text-3xl font-bold text-gray-900">Unlock the Full Interactive Tool</h3>
                     <p class="mt-3 text-gray-600">Fill out the form below to get instant, free access.</p>
                 </div>
-                <div class="mt-8">
-                    <!-- 
-                      INSTRUCTIONS FOR CONTACT FORM 7:
-                      1. Create your form in the Contact Form 7 plugin in WordPress.
-                      2. Get the shortcode for your form (e.g., [contact-form-7 id="123" title="Access Form"]).
-                      3. Paste that shortcode directly below this comment.
-                      4. The CSS in the <style> block at the top of this file will automatically style your form to match the page design.
-                    -->
-
-                    <!-- PASTE YOUR CONTACT FORM 7 SHORTCODE HERE -->
-                    [contact-form-7 id="0779c74" title="Video Access Gate Form"]
-                    
+                <div class="mt-8 text-center">
+                    <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/#openVideoModal" class="px-10 py-4 text-lg text-white font-bold rounded-xl primary-gradient primary-gradient-hover transition-all duration-300 shadow-xl hover:shadow-2xl transform hover:-translate-y-1 inline-block">
+                        Unlock the Full Tool Instantly
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the contact form block in `#lead-form`
- add a CTA button styled the same as the hero button
- point the CTA button to the provided video modal link

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685acc51c9288331a3ced7da3a4b35c9