### PR TITLE
Add popup form modal for video links

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,29 @@
         </div>
     </footer>
 
+  <!-- Popup Form Modal -->
+  <div id="openVideoModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 hidden">
+    <div class="bg-white rounded-xl p-8 w-full max-w-lg relative">
+      <button id="closeModal" class="absolute top-3 right-3 text-gray-500 hover:text-gray-700 text-2xl leading-none">&times;</button>
+      <h3 class="text-2xl font-bold mb-4">Unlock the Full Interactive Tool</h3>
+      <form class="space-y-4">
+        <input type="text" placeholder="Name" class="w-full p-3 border rounded-md" />
+        <input type="email" placeholder="Email" class="w-full p-3 border rounded-md" />
+        <button type="submit" class="w-full primary-gradient primary-gradient-hover text-white font-bold py-3 rounded-md">Submit</button>
+      </form>
+    </div>
+  </div>
+  <script>
+  document.querySelectorAll('a[href="#openVideoModal"]').forEach(function(link){
+    link.addEventListener('click', function(e){
+      e.preventDefault();
+      document.getElementById('openVideoModal').classList.remove('hidden');
+    });
+  });
+  document.getElementById('closeModal').addEventListener('click', function(){
+    document.getElementById('openVideoModal').classList.add('hidden');
+  });
+  </script>
     <!-- No script needed anymore as CF7 handles form submission -->
 
 </body>


### PR DESCRIPTION
## Summary
- add a hidden modal containing a form
- show modal when any `#openVideoModal` link is clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685acf96a6ec8331836b58db09c0549a